### PR TITLE
Convert selectable list from Vuetify to Carbon Vue.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,19 +8,13 @@
       sm="4"
     >
     <v-card>
-       <v-list>
-         <v-subheader>SELECT ENVIRONMENT</v-subheader>
-         <v-list-item-group
-           v-model="selectedEnvIndex"
-           color="primary">
-           <v-list-item
-             v-for="env in envs"
-             :key="env"
-           >
-             {{ env }}
-           </v-list-item>
-         </v-list-item-group>
-       </v-list>
+      <v-subheader>SELECT ENVIRONMENT</v-subheader>
+      <cv-multi-select
+        :label="envSelectLabel"
+        :options="envs"
+        v-model="selectedEnvIndex"
+      >
+      </cv-multi-select>
     </v-card>
     </v-col>
 
@@ -82,6 +76,7 @@ import axios from 'axios';
 import {
   CvDataTable,
   CvDataTableHeading,
+  CvMultiSelect,
   CvSearch
 } from '@carbon/vue';
 import Network from './components/Network';
@@ -92,12 +87,14 @@ export default {
   components: {
     CvDataTable,
     CvDataTableHeading,
+    CvMultiSelect,
     CvSearch,
     Network
   },
 
   data: () => ({
     envs: [],
+    envSelectLabel: 'Click one environment prefix',
     items: [],
     selectedEnvIndex: [],
     selectedEnvName: '',
@@ -164,16 +161,24 @@ export default {
     getEnvs() {
       let url = this.baseUrl + '/' + 'envs';
       axios.get(url).then((response) => {
-        this.envs = response.data.envs;
+        let li = response.data.envs;
+        this.envs = li.map(el => {
+          let envName = el.split('/').pop();
+          if (envName.includes('miniconda') || envName.includes('anaconda')) {
+            envName = 'base';
+          }
+          return {
+            name: el,
+            label: el,
+            value: envName,
+          };
+        })
       }).catch(error => { console.log(error); });
     },
     getEnvName() {
-      let name = this.envs[this.selectedEnvIndex].split('/').pop();
-      if (name.includes('miniconda') || name.includes('anaconda')) {
-        this.selectedEnvName = 'base';
-      } else {
-        this.selectedEnvName = name;
-      }
+      // forces single select
+      this.selectedEnvIndex = this.selectedEnvIndex.pop();
+      this.selectedEnvName = this.selectedEnvIndex;
     },
     getPkgs() {
       let reqUrl = this.baseUrl + '/envs/' + this.selectedEnvName;

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
       <cv-multi-select
         :label="envSelectLabel"
         :options="envs"
-        v-model="selectedEnvIndex"
+        v-model="selectedEnv"
       >
       </cv-multi-select>
     </v-card>
@@ -23,7 +23,7 @@
       sm="4"
     >
     <v-card>
-      <p>Selected environment (name): {{ selectedEnvName }}</p>
+      <p>Selected environment (name): {{ selectedEnv }}</p>
     </v-card>
     <v-card>
       <v-subheader>SELECT PACKAGE</v-subheader>
@@ -96,8 +96,7 @@ export default {
     envs: [],
     envSelectLabel: 'Click one environment prefix',
     items: [],
-    selectedEnvIndex: [],
-    selectedEnvName: '',
+    selectedEnv: [],
     selectedPkg: [],
     selectedPkgName: [],
     searchPkg: '',
@@ -111,17 +110,14 @@ export default {
     searchColumns: ["Channel", "Build"]
   }),
   watch: {
-    // whenever selectedEnvIndex changes, this function will run
-    selectedEnvIndex: function () {
-      this.getEnvName()
+    // whenever selectedEnv changes, this function will run
+    selectedEnv: function () {
+      this.getEnvName(),
+      this.getPkgs()
     },
     // whenever selectedPkg changes, this function will run
     selectedPkg: function () {
       this.getPkgName()
-    },
-    // whenever selectedEnvName changes, this function will run
-    selectedEnvName: function () {
-      this.getPkgs()
     },
     // whenever searchPkg changes, this function will run
     searchPkg: function () {
@@ -177,11 +173,10 @@ export default {
     },
     getEnvName() {
       // forces single select
-      this.selectedEnvIndex = this.selectedEnvIndex.pop();
-      this.selectedEnvName = this.selectedEnvIndex;
+      this.selectedEnv = this.selectedEnv.pop();
     },
     getPkgs() {
-      let reqUrl = this.baseUrl + '/envs/' + this.selectedEnvName;
+      let reqUrl = this.baseUrl + '/envs/' + this.selectedEnv;
       axios.get(reqUrl).then((response) => {
         this.items = response.data;
       }).catch(error => { console.log(error); });


### PR DESCRIPTION
Hi @mariobuikhuizen and @wolfv,

I've continued the conversion effort from Vuetify to Carbon Vue components. After the search bar, I tackled the list which lets the user select an environment (on the LHS in the current layout).
  
I haven't cleaned up the code.

Edit: "For example, we could spare one variable (`selectedEnvIndex` and `selectedEnvName` could now be merged into a single new variable `selectedEnv`)." Done in b413062a8ccde61c0b046ebd66f63e58d88d9145.

I have spent a lot of time tweaking [CvDataTable](http://vue.carbondesignsystem.com/?path=/story/components-cvdatatable--default) to no avail. The rendering was similar to the current version of the app:
![CvDataTable](https://user-images.githubusercontent.com/2227806/85276612-66b35b80-b482-11ea-944b-268e4eff5d14.png)

But I couldn't get `v-model` (nor `:rows-selected`) to work... So I turned to [CvMultiSelect](http://vue.carbondesignsystem.com/?path=/story/components-cvmultiselect--default) after stumbling upon this toy example: https://codepen.io/lee-chase/pen/ymaRer The rendering is different and less intuitive, but the functionality is there:

![CvMultiSelect](https://user-images.githubusercontent.com/2227806/85276919-d1fd2d80-b482-11ea-941a-1b461c15418f.png)
