### PR TITLE
Replace Vuetify component with Carbon Vue component for multiple selection of packages.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,6 @@ export default {
     items: [],
     pkgSelectLabel: 'View dependency graph for...',
     selectedPkg: [],
-    selectedPkgName: [],
     searchPkg: '',
     searchItems: [],
     baseUrl: 'http://0.0.0.0:5000',
@@ -187,15 +186,8 @@ export default {
     },
     getDepGraph() {
       this.componentKey += 1;
-      let pkg = this.selectedPkg[0];
-      if (pkg && pkg.name) {
-        let pkgNames = this.selectedPkg.map(function (i) { return i.name; });
-        this.selectedPkgName = pkgNames;
-      } else {
-        this.selectedPkgName = ['python'];
-      }
       let url = this.baseUrl + '/pkgs';
-      this.depUrl = this.selectedPkgName.map(function (i) { return url + '/' + i });
+      this.depUrl = this.selectedPkg.map(function (i) { return url + '/' + i });
       this.depData = this.depUrl.map(u => fetch(u).then(resp => resp.json()));
     },
     getChannels() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,8 +32,6 @@
         :options="items"
         v-model="selectedPkg"
       >
-        <template v-slot:top>
-        </template>
       </cv-multi-select>
     </v-card>
     <v-card>

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,7 +114,7 @@ export default {
     },
     // whenever selectedPkg changes, this function will run
     selectedPkg: function () {
-      this.getPkgName()
+      this.getDepGraph()
     },
     // whenever searchPkg changes, this function will run
     searchPkg: function () {
@@ -185,7 +185,7 @@ export default {
         })
       }).catch(error => { console.log(error); });
     },
-    getPkgName() {
+    getDepGraph() {
       this.componentKey += 1;
       let pkg = this.selectedPkg[0];
       if (pkg && pkg.name) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,19 +26,15 @@
       <p>Selected environment (name): {{ selectedEnv }}</p>
     </v-card>
     <v-card>
-      <v-subheader>SELECT PACKAGE</v-subheader>
-      <v-data-table
+      <v-subheader>SELECT PACKAGE(S)</v-subheader>
+      <cv-multi-select
+        :label="pkgSelectLabel"
+        :options="items"
         v-model="selectedPkg"
-        :headers="columns"
-        :items="items"
-        :single-select=false
-        item-key="name"
-        show-select
-        class="elevation-1"
       >
         <template v-slot:top>
         </template>
-      </v-data-table>
+      </cv-multi-select>
     </v-card>
     <v-card>
       <Network :data-promise="depData" :key="componentKey"></Network>
@@ -95,8 +91,9 @@ export default {
   data: () => ({
     envs: [],
     envSelectLabel: 'Click one environment prefix',
-    items: [],
     selectedEnv: [],
+    items: [],
+    pkgSelectLabel: 'View dependency graph for...',
     selectedPkg: [],
     selectedPkgName: [],
     searchPkg: '',
@@ -178,7 +175,14 @@ export default {
     getPkgs() {
       let reqUrl = this.baseUrl + '/envs/' + this.selectedEnv;
       axios.get(reqUrl).then((response) => {
-        this.items = response.data;
+        let pk = response.data;
+        this.items = pk.map(el => {
+          return {
+            name: el.name,
+            label: el.name + ' ' + el.version,
+            value: el.name,
+          };
+        })
       }).catch(error => { console.log(error); });
     },
     getPkgName() {


### PR DESCRIPTION
Hi @wolfv and @mariobuikhuizen,

I just converted the third and last component to Carbon Vue (the middle one, in the current layout).
The logic shines better, actually (e.g., c809b79).

I guess the app is now ready to get multi-paged.
Would you like me to get rid of the Vuetify dependency altogether first?

Edit: Let me attach a screenshot of the app with these changes:
![third_cv_comp](https://user-images.githubusercontent.com/2227806/86028276-fe401d80-ba31-11ea-8f13-c7fbbc3ed79d.png)
 