### PR TITLE
Add Binder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# hack-frontend
+# Mamba Navigator
+
+## Try it online
 
 Open Mamba Navigator:
 
@@ -8,7 +10,10 @@ Open JupyterLab:
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TheSnakePit/mamba-navigator/master?urlpath=lab)
 
+![lab-launcher](https://user-images.githubusercontent.com/591645/92235600-3d687000-eeb4-11ea-8f8a-c4d4f14a4d4b.png)
+
 ## Mimic mamba backend
+
 Activate an environment with these [requirements](./server/requirements.txt)
 and run:
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # hack-frontend
 
+Open Mamba Navigator:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TheSnakePit/mamba-navigator/master?urlpath=mamba/navigator)
+
+Open JupyterLab:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TheSnakePit/mamba-navigator/master?urlpath=lab)
+
 ## Mimic mamba backend
 Activate an environment with these [requirements](./server/requirements.txt)
 and run:

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,6 @@ with open(os.path.join(HERE, 'package.json')) as fid:
     version = json.load(fid)['version']
 
 class MambaNavigator(LabServerApp):
-    base_url = '/'
     default_url = Unicode('/navigator',
                           help='The default URL to redirect to from `/`')
 
@@ -36,13 +35,7 @@ class MambaNavigator(LabServerApp):
     )
 
     def start(self):
-        settings = self.web_app.settings
-
-        # By default, make terminals available.
-        settings.setdefault('terminals_available', True)
-
         load_jupyter_server_extension(self)
-
         super().start()
 
 if __name__ == '__main__':

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,13 +6,14 @@
 <body>
     {# Copy so we do not modify the page_config with updates. #}
     {% set page_config_full = page_config.copy() %}
-    
+
     {# Set a dummy variable - we just want the side effect of the update. #}
     {% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
-    
+
       <script id="jupyter-config-data" type="application/json">
         {{ page_config_full | tojson }}
       </script>
+
   <script src="{{page_config['fullStaticUrl'] | e}}/bundle.js" main="index"></script>
 
   <script type="text/javascript">

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,10 @@
+name: mamba-navigator
+channels:
+- conda-forge
+dependencies:
+- yarn
+- nodejs=12
+- jupyterlab=2
+- jupyterlab_server
+- jupyter_conda
+- jupyter-server-proxy

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -1,0 +1,23 @@
+import sys
+
+c.ServerProxy.servers = {
+    "mamba": {
+        "command": [
+            sys.executable,
+            "app/main.py",
+            "--no-browser",
+            '--port={port}',
+            "--ip=0.0.0.0",
+            "--NotebookApp.token=''",
+            "--NotebookApp.base_url={base_url}mamba",
+            "--NotebookApp.allow_remote_access=True",
+        ],
+        "timeout": 120,
+        "absolute_url": True,
+        "launcher_entry": {
+            "enabled": True,
+            "icon_path": "/home/jovyan/app/style/mamba.svg",
+            "title": "Mamba Navigator",
+        },
+    },
+}

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+export NODE_OPTIONS="--max_old_space_size=4096"
+
+cd app/
+yarn
+yarn run build
+
+jupyter labextension install @jupyterlab/server-proxy jupyterlab_conda --no-build
+jupyter lab build --minimize=False
+
+mkdir -p $HOME/.jupyter/
+cp ../binder/jupyter_notebook_config.py ${HOME}/.jupyter/


### PR DESCRIPTION
Fixes #10. 

Start the navigator in a separate process using [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy).

The idea is to be able to:

- Start JupyterLab with a launcher icon to the mamba navigator
- Install the `jupyter_conda` lab extension, so both the original extension and the mamba navigator are available on the same Binder instance
- Switch the mamba navigator backend if we want to use something else instead (although the current `jupyterlab_server` sounds like a good fit for now)

WIP on Binder here:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/mamba-navigator/binder?urlpath=mamba/navigator)

![image](https://user-images.githubusercontent.com/591645/92235600-3d687000-eeb4-11ea-8f8a-c4d4f14a4d4b.png)

### TODO

- [x] `jupyter-server-proxy` config to start the navigator on Binder
- [x] Add `jupyter_conda` lab extension
